### PR TITLE
reset imgui on dx9device change

### DIFF
--- a/LR2ArenaEx/src/overlay/dx9hook.h
+++ b/LR2ArenaEx/src/overlay/dx9hook.h
@@ -15,6 +15,7 @@ namespace overlay {
 		typedef long(__stdcall* ResetScene)(LPDIRECT3DDEVICE9, D3DPRESENT_PARAMETERS*);
 		inline ResetScene oResetScene;
 		inline WNDPROC oWndProcHandler = NULL;
+		inline IDirect3DDevice9* lastKnownDevice = NULL;
 
 		typedef long(__cdecl* ShowCursor)(int);
 		inline ShowCursor oShowCursor;


### PR DESCRIPTION
This allows ImGui to work when LR2 runs in fullscreen, as it recreates the device to enter it after loading.