### PR TITLE
no debug console in release build

### DIFF
--- a/LR2ArenaEx/src/overlay/overlay.cpp
+++ b/LR2ArenaEx/src/overlay/overlay.cpp
@@ -9,7 +9,11 @@
 #include "dx9hook.h"
 #include "dinputhook.h"
 
-#define DEBUG_CONSOLE_ENABLED
+#ifndef _DEBUG
+#define DEBUG_CONSOLE_ENABLED 0
+#else
+#define DEBUG_CONSOLE_ENABLED 1
+#endif
 
 DWORD WINAPI overlay::Setup(HMODULE hModule)
 {


### PR DESCRIPTION
DEBUG_CONSOLE_ENABLED define depends on build type. Implicitly sets the value for quick edit in case you do need the console in release build, that you could flip this value manually.