### PR TITLE
toggle for automatic graph, save muteInput

### DIFF
--- a/LR2ArenaEx/src/config/config.cpp
+++ b/LR2ArenaEx/src/config/config.cpp
@@ -3,6 +3,8 @@
 #include <client/client.h>
 #include <hooks/maniac.h>
 #include <hooks/fmod.h>
+#include <gui/gui.h>
+#include <gui/graph.h>
 
 #include "config.h"
 
@@ -27,6 +29,16 @@ void config::LoadConfig() {
 	auto itemVolume = ini.get("config").get("item_sound_volume");
 	auto sfxConfig = ini.get("sfx");
 	hooks::fmod::LoadConfig(itemVolume, sfxConfig);
+
+	auto muteInputs = ini.get("config").get("muteInputs");
+	if (!muteInputs.empty()) {
+		gui::muteGameInputs = muteInputs == "true" ? true : false;
+	}
+
+	auto automaticGraph = ini.get("config").get("automaticGraph");
+	if (!automaticGraph.empty()) {
+		gui::graph::automaticGraph = automaticGraph == "true" ? true : false;
+	}
 }
 
 void config::SetConfigValue(std::string key, std::string val, std::string section) {

--- a/LR2ArenaEx/src/gui/graph.h
+++ b/LR2ArenaEx/src/gui/graph.h
@@ -15,6 +15,7 @@ namespace gui {
 		};
 
 		inline bool showGraph = false;
+		inline bool automaticGraph = true;
 		inline std::unordered_map<overlay::LR2_TYPE, ImVec2> graphDim = {
 			{overlay::LR2_TYPE::LR2_HD, ImVec2(150, 400)},
 			{overlay::LR2_TYPE::LR2_SD, ImVec2(100, 200)},

--- a/LR2ArenaEx/src/gui/gui.cpp
+++ b/LR2ArenaEx/src/gui/gui.cpp
@@ -1,6 +1,7 @@
 #include "gui.h"
 #include "widgets.h"
 #include "mainwindow.h"
+#include "graph.h"
 
 #include <server/server.h>
 #include <client/client.h>
@@ -8,6 +9,7 @@
 #include <hooks/fmod.h>
 #include <overlay/dx9hook.h>
 #include <ImGui/ImGuiFileDialog.h>
+#include <config/config.h>
 
 void gui::Render() {
 	if (ImGui::Begin("LR2ArenaEx", &showMenu, ImGuiWindowFlags_AlwaysAutoResize | ImGuiWindowFlags_NoResize | ImGuiWindowFlags_NoFocusOnAppearing | ImGuiWindowFlags_NoBringToFrontOnFocus))
@@ -64,8 +66,16 @@ void gui::Render() {
             if (ImGui::BeginTabItem("Settings"))
             {
                 ImGui::SeparatorText("Settings");
-                ImGui::Checkbox("Disable game inputs when overlay is shown", &gui::muteGameInputs);
+                if (ImGui::Checkbox("Disable game inputs when overlay is shown", &gui::muteGameInputs)) {
+                    config::SetConfigValue("muteInputs", gui::muteGameInputs ? "true": "false");
+                    config::SaveConfig();
+                }
                 ImGui::SameLine(); widgets::HelpMarker("Does not affect the graph display in-game");
+
+                if (ImGui::Checkbox("Hide/show graph window automatically on scene transitions", &gui::graph::automaticGraph)) {
+                    config::SetConfigValue("automaticGraph", gui::graph::automaticGraph ? "true" : "false");
+                    config::SaveConfig();
+                }
 
                 static int volumeTmp = hooks::fmod::volume;
                 ImGui::SliderInt("Item sounds volume", &volumeTmp, 0, 100, "%d%%", ImGuiSliderFlags_AlwaysClamp);

--- a/LR2ArenaEx/src/hooks/returnmenu.cpp
+++ b/LR2ArenaEx/src/hooks/returnmenu.cpp
@@ -16,7 +16,9 @@ void hkReturnMenu() {
 		return;
 	}
 	hooks::return_menu::is_returning_to_menu = true;
-	gui::graph::showGraph = false;
+	if (gui::graph::automaticGraph) {
+		gui::graph::showGraph = false;
+	}
 	hooks::maniac::ResetState();
 	client::Send(network::ClientToServer::CTS_CHART_CANCELLED, ""); // send escaped
 }

--- a/LR2ArenaEx/src/hooks/selectbms.cpp
+++ b/LR2ArenaEx/src/hooks/selectbms.cpp
@@ -74,7 +74,10 @@ void hkSelectBms(const char** buffer, unsigned char* memory) {
 		if (!(client::state.host == client::state.remoteId) && bmsInfo.hash != client::state.selectedSongRemote.hash)
 			gui::main_window::AddToLog("[!] You are not the host; please go back to the main menu and select the same song as the host!");
 
-		gui::graph::showGraph = true; // Show graph on song select
+		if (gui::graph::automaticGraph) {
+			gui::graph::showGraph = true; // Show graph on song select
+		}
+
 		hooks::return_menu::is_returning_to_menu = false;
 		hooks::maniac::ResetState();
 	}

--- a/LR2ArenaEx/src/hooks/selectscene.cpp
+++ b/LR2ArenaEx/src/hooks/selectscene.cpp
@@ -7,7 +7,9 @@
 #include "selectscene.h"
 
 void hkSelectScene() {
-	gui::graph::showGraph = false;
+	if (gui::graph::automaticGraph) {
+		gui::graph::showGraph = false;
+	}
 }
 
 DWORD jmp_lr2body_43C510 = 0x43C510;


### PR DESCRIPTION
adds a toggle for a feature of automatically hiding/showing the graph screen, which saves to config, as well as saves the "mute input" toggle to the config. I accidentally edited wrong line when making save to config, but thought "mute config" should probably save indeed, so it's there now...