### PR TITLE
changes for DxLib3.24f

### DIFF
--- a/LR2ArenaEx/LR2ArenaEx.vcxproj
+++ b/LR2ArenaEx/LR2ArenaEx.vcxproj
@@ -116,6 +116,7 @@
       <UseFullPaths>false</UseFullPaths>
       <RuntimeLibrary>MultiThreadedDebugDLL</RuntimeLibrary>
       <LanguageStandard>stdcpp17</LanguageStandard>
+      <Optimization>Disabled</Optimization>
     </ClCompile>
     <Link>
       <SubSystem>Console</SubSystem>

--- a/LR2ArenaEx/include/ImGui/ImGuiNotify.hpp
+++ b/LR2ArenaEx/include/ImGui/ImGuiNotify.hpp
@@ -494,7 +494,7 @@ namespace ImGui
     {
         //const ImVec2 mainWindowSize = GetMainViewport()->Size;
         // Use LR2's internal resolution as window size instead otherwise it gets rendered outside of the window
-        const ImVec2 mainWindowSize = ImVec2((float)((uintptr_t*)overlay::dx9hook::internal_resolution)[0], (float)((uintptr_t*)overlay::dx9hook::internal_resolution)[1]);
+        const ImVec2 mainWindowSize = ImVec2((float)((uintptr_t*)overlay::dx9hook::canvas_resolution)[0], (float)((uintptr_t*)overlay::dx9hook::canvas_resolution)[1]);
 
         float height = 0.f;
 

--- a/LR2ArenaEx/src/gui/gui.cpp
+++ b/LR2ArenaEx/src/gui/gui.cpp
@@ -148,7 +148,7 @@ void gui::Render() {
                 if (waitingForKeyPress != utils::keys::BindingType::NONE)
                     ImGui::OpenPopup("Bind key");
 
-                ImVec2 center = ImVec2((float)((uintptr_t*)overlay::dx9hook::internal_resolution)[0] / 2.0f, (float)((uintptr_t*)overlay::dx9hook::internal_resolution)[1] / 2.0f);
+                ImVec2 center = ImVec2((float)((uintptr_t*)overlay::dx9hook::canvas_resolution)[0] / 2.0f, (float)((uintptr_t*)overlay::dx9hook::canvas_resolution)[1] / 2.0f);
                 ImGui::SetNextWindowPos(center, ImGuiCond_Appearing, ImVec2(0.5f, 0.5f));
 
                 if (ImGui::BeginPopupModal("Bind key", NULL, ImGuiWindowFlags_AlwaysAutoResize))
@@ -178,7 +178,7 @@ void gui::Render() {
         ImGuiFileDialog::Instance()->SetFileStyle(IGFD_FileStyleByExtention, ".ogg", ImVec4(1.0f, 1.0f, 1.0f, 0.9f), ICON_FA_MUSIC);
         ImGuiFileDialog::Instance()->SetFileStyle(IGFD_FileStyleByExtention, ".mp3", ImVec4(1.0f, 1.0f, 1.0f, 0.9f), ICON_FA_MUSIC);
 
-        ImVec2 center = ImVec2((float)((uintptr_t*)overlay::dx9hook::internal_resolution)[0] / 2.0f, (float)((uintptr_t*)overlay::dx9hook::internal_resolution)[1] / 2.0f);
+        ImVec2 center = ImVec2((float)((uintptr_t*)overlay::dx9hook::canvas_resolution)[0] / 2.0f, (float)((uintptr_t*)overlay::dx9hook::canvas_resolution)[1] / 2.0f);
         ImGui::SetNextWindowPos(center, ImGuiCond_Appearing, ImVec2(0.5f, 0.5f));
 
         if (ImGuiFileDialog::Instance()->Display("ChooseAudioFileDlg", ImGuiWindowFlags_NoCollapse, fileDialogDim[overlay::lr2type])) {

--- a/LR2ArenaEx/src/gui/itemsettings.cpp
+++ b/LR2ArenaEx/src/gui/itemsettings.cpp
@@ -7,7 +7,7 @@
 #include "widgets.h"
 
 void gui::item_settings::Render() {
-    ImVec2 center = ImVec2((float)((uintptr_t*)overlay::dx9hook::internal_resolution)[0] / 2.0f, (float)((uintptr_t*)overlay::dx9hook::internal_resolution)[1] / 2.0f);
+    ImVec2 center = ImVec2((float)((uintptr_t*)overlay::dx9hook::canvas_resolution)[0] / 2.0f, (float)((uintptr_t*)overlay::dx9hook::canvas_resolution)[1] / 2.0f);
     ImGui::SetNextWindowPos(center, ImGuiCond_Appearing, ImVec2(0.5f, 0.5f));
 
     if (ImGui::BeginPopupModal("Item settings", NULL, ImGuiWindowFlags_AlwaysAutoResize))

--- a/LR2ArenaEx/src/overlay/dinputhook.cpp
+++ b/LR2ArenaEx/src/overlay/dinputhook.cpp
@@ -68,6 +68,7 @@ HRESULT __stdcall hkGetDeviceState(IDirectInputDevice7* pThis, DWORD cbData, LPV
 			if (cbData == sizeof(DIMOUSESTATE2)) { // Mouse device
 				((LPDIMOUSESTATE2)lpvData)->rgbButtons[0] = 0;
 				((LPDIMOUSESTATE2)lpvData)->rgbButtons[1] = 0;
+				((LPDIMOUSESTATE2)lpvData)->lZ = 0;
 			}
 			else if (cbData == 256) { // Keyboard device
 				memset(lpvData, 0, 256);
@@ -81,26 +82,82 @@ HRESULT __stdcall hkGetDeviceState(IDirectInputDevice7* pThis, DWORD cbData, LPV
 	return result;
 }
 
-BOOL overlay::dinputhook::HookDinput(HMODULE hModule) {
-	IDirectInput7* pDirectInput = NULL;
-	if (DirectInputCreateEx(hModule, DIRECTINPUT_VERSION, IID_IDirectInput7A, (LPVOID*)&pDirectInput, NULL) != DI_OK) {
-		std::cout << "[i] DirectInputCreateEx failed" << std::endl;
-		return false;
+static overlay::dinputhook::GetDeviceState GetDeviceStatePtr7(HMODULE hModule) {
+	IDirectInput7A* pDirectInput = NULL;
+	typedef HRESULT(__stdcall* tDirectInputCreateEx)(HINSTANCE hinst,
+		DWORD dwVersion,
+		REFIID riidltf,
+		LPVOID* ppvOut,
+		LPUNKNOWN punkOuter);
+	tDirectInputCreateEx DirectInputCreateEx = (tDirectInputCreateEx)GetProcAddress(hModule, "DirectInputCreateEx");
+	if (DirectInputCreateEx == nullptr) {
+		std::cout << "[!] DirectInputCreateEx not present in dinput.dll" << std::endl;
+		return nullptr;
+	}
+	GUID IID_IDirectInput7A = { 0x9A4CB684,0x236D,0x11D3,0x8E,0x9D,0x00,0xC0,0x4F,0x68,0x44,0xAE };
+	if (DirectInputCreateEx(GetModuleHandle(NULL), 0x0700, IID_IDirectInput7A, (LPVOID*)&pDirectInput, NULL) != DI_OK) {
+		std::cout << "[!] DirectInputCreateEx failed" << std::endl;
+		return nullptr;
 	}
 
-	LPDIRECTINPUTDEVICE7 lpdiMouse;
+	LPDIRECTINPUTDEVICE7A lpdiMouse;
+	GUID GUID_SysMouse = { 0x6F1D2B60, 0xD5A0, 0x11CF, 0xBF, 0xC7, 0x44, 0x45, 0x53, 0x54, 0x00, 0x00 };
+	GUID IID_IDirectInputDevice7A = { 0x57D7C6BC,0x2356,0x11D3,0x8E,0x9D,0x00,0xC0,0x4F,0x68,0x44,0xAE };
 	if (pDirectInput->CreateDeviceEx(GUID_SysMouse, IID_IDirectInputDevice7A, (LPVOID*)&lpdiMouse, NULL) != DI_OK) {
 		pDirectInput->Release();
-		std::cout << "[!] Error creating DirectInput device" << std::endl;
-		return false;
+		std::cout << "[!] Error creating DirectInput7 device" << std::endl;
+		return nullptr;
 	}
 
-	uintptr_t vTable = mem::FindDMAAddy((uintptr_t)lpdiMouse, { 0x0 });
+	void** vTable = reinterpret_cast<void**>(mem::FindDMAAddy((uintptr_t)lpdiMouse, { 0x0 }));
 
-	std::cout << "[i] DInput device pointer: " << std::hex << lpdiMouse << std::endl;
-	std::cout << "[i] DInput vTable pointer: " << std::hex << vTable << std::endl;
-	std::cout << "[i] GetDeviceState pointer: " << std::hex << ((int*)vTable)[9] << std::endl;
-	oGetDeviceState = (GetDeviceState)((char**)vTable)[9];
+	lpdiMouse->Release();
+	pDirectInput->Release();
+
+	return reinterpret_cast<overlay::dinputhook::GetDeviceState>(vTable[9]);
+}
+
+static overlay::dinputhook::GetDeviceState GetDeviceStatePtr8(HMODULE hModule) {
+	IDirectInput8A* pDirectInput = NULL;
+	decltype(DirectInput8Create)* DirectInput8Create = reinterpret_cast<decltype(DirectInput8Create)>(GetProcAddress(hModule, "DirectInput8Create"));
+	if (DirectInput8Create == nullptr) {
+		std::cout << "[!] DirectInput8Create not present in dinput8.dll" << std::endl;
+		return nullptr;
+	}
+	GUID IID_IDirectInput8A = { 0xBF798030,0x483A,0x4DA2,0xAA,0x99,0x5D,0x64,0xED,0x36,0x97,0x00 };
+	if (DirectInput8Create(GetModuleHandle(NULL), 0x0800, IID_IDirectInput8A, (LPVOID*)&pDirectInput, NULL) != DI_OK) {
+		std::cout << "[!] DirectInput8Create failed" << std::endl;
+		return nullptr;
+	}
+
+	LPDIRECTINPUTDEVICE8A lpdiMouse;
+	GUID GUID_SysMouse = { 0x6F1D2B60, 0xD5A0, 0x11CF, 0xBF, 0xC7, 0x44, 0x45, 0x53, 0x54, 0x00, 0x00 };
+	if (pDirectInput->CreateDevice(GUID_SysMouse, &lpdiMouse, NULL) != DI_OK) {
+		pDirectInput->Release();
+		std::cout << "[!] Error creating DirectInput8 device" << std::endl;
+		return nullptr;
+	}
+
+	void** vTable = reinterpret_cast<void**>(mem::FindDMAAddy((uintptr_t)lpdiMouse, { 0x0 }));
+
+	lpdiMouse->Release();
+	pDirectInput->Release();
+
+	return reinterpret_cast<overlay::dinputhook::GetDeviceState>(vTable[9]);
+}
+
+BOOL overlay::dinputhook::HookDinput(HMODULE hModule) {
+	int ver = 0;
+	HMODULE dinputHandle7 = GetModuleHandle("dinput.dll");
+	if (dinputHandle7) ver = 7;
+	HMODULE dinputHandle8 = GetModuleHandle("dinput8.dll");
+	if (dinputHandle8) ver = 8;
+
+	switch (ver) {
+	case 7: oGetDeviceState = GetDeviceStatePtr7(dinputHandle7); break;
+	case 8: oGetDeviceState = GetDeviceStatePtr8(dinputHandle8); break;
+	default: std::cout << "[!] DirectInput not found" << std::endl; return false;
+	}
 	if (MH_CreateHookEx((LPVOID)oGetDeviceState, &hkGetDeviceState, &oGetDeviceState) != MH_OK)
 	{
 		std::cout << "[!] Error hooking GetDeviceState" << std::endl;
@@ -112,9 +169,6 @@ BOOL overlay::dinputhook::HookDinput(HMODULE hModule) {
 		std::cout << ("[!] Error enabling dinput hooks") << std::endl;
 		return false;
 	}
-
-	lpdiMouse->Release();
-	pDirectInput->Release();
 
 	return true;
 }

--- a/LR2ArenaEx/src/overlay/dinputhook.h
+++ b/LR2ArenaEx/src/overlay/dinputhook.h
@@ -1,12 +1,10 @@
 #pragma once
 
 #include <framework.h>
-#define DIRECTINPUT_VERSION 0x0700 // DirectInput 7!!! (August 2007 SDK required)
+#define DIRECTINPUT_VERSION 0x0800 // DirectInput 7!!! (August 2007 SDK required)
 #include <dinput.h>
 #include <unordered_map>
 #include <utils/keys.h>
-#pragma comment(lib, "Dinput.lib")
-#pragma comment(lib, "Dxguid.lib")
 
 namespace overlay {
 	namespace dinputhook {

--- a/LR2ArenaEx/src/overlay/dx9hook.cpp
+++ b/LR2ArenaEx/src/overlay/dx9hook.cpp
@@ -1,4 +1,4 @@
-ï»¿#include <ImGui/imgui.h>
+#include <ImGui/imgui.h>
 #include <ImGui/imgui_impl_win32.h>
 #include <ImGui/imgui_impl_dx9.h>
 #include <ImGui/implot.h>
@@ -14,6 +14,7 @@
 #include <fonts/IconsFontAwesome6.h>
 #include <MinHook.h>
 #include <optional>
+#include <thread>
 
 #include "dx9hook.h"
 #include "overlay.h"
@@ -22,9 +23,18 @@ extern IMGUI_IMPL_API LRESULT ImGui_ImplWin32_WndProcHandler(HWND hWnd, UINT msg
 
 bool ShouldMuteMessage(UINT uMsg) {
 	const UINT toMute[] = {
+		WM_LBUTTONDOWN,
+		WM_LBUTTONUP,
+		WM_LBUTTONDBLCLK,
+		WM_RBUTTONDOWN,
+		WM_RBUTTONUP,
+		WM_RBUTTONDBLCLK,
 		WM_MOUSEHWHEEL,
 		WM_MOUSEWHEEL,
-		WM_SETCURSOR
+		WM_SETCURSOR,
+		WM_KEYDOWN,
+		WM_KEYUP,
+		WM_CHAR
 	};
 	for (const UINT m : toMute) {
 		if (uMsg == m)
@@ -42,12 +52,25 @@ LRESULT __stdcall hkWndProc(const HWND hWnd, UINT uMsg, WPARAM wParam, LPARAM lP
 		GetClientRect(hWnd, &r);
 		int physical_resolution[2] = { r.right - r.left, r.bottom - r.top };
 
-		float scaling_factor_x = (float)((uintptr_t*)overlay::dx9hook::internal_resolution)[0] / physical_resolution[0];
-		float scaling_factor_y = (float)((uintptr_t*)overlay::dx9hook::internal_resolution)[1] / physical_resolution[1];
+		float scaling_factor_x = (float)((uintptr_t*)overlay::dx9hook::canvas_resolution)[0] / physical_resolution[0];
+		float scaling_factor_y = (float)((uintptr_t*)overlay::dx9hook::canvas_resolution)[1] / physical_resolution[1];
 
 		POINT mouse_pos = { GET_X_LPARAM(lParam), GET_Y_LPARAM(lParam) };
 		mouse_pos.x *= scaling_factor_x;
 		mouse_pos.y *= scaling_factor_y;
+
+		float canvasAR = (float)overlay::dx9hook::canvas_resolution[0] / overlay::dx9hook::canvas_resolution[1];
+		float outputAR = (float)overlay::dx9hook::output_resolution[0] / overlay::dx9hook::output_resolution[1];
+		if (canvasAR != outputAR) {
+			bool horizontal = canvasAR > outputAR;
+			auto& pos = horizontal ? mouse_pos.y : mouse_pos.x;
+			float size = horizontal ? overlay::dx9hook::output_resolution[1] : overlay::dx9hook::output_resolution[0];
+			float scale = size / (size / canvasAR);
+			float& scalePos = horizontal ? scaling_factor_y : scaling_factor_x;
+			pos *= scale;
+			pos -= (size - size / canvasAR) / 2 * scalePos * scale;
+		}
+
 		imgui_lParam = MAKELPARAM(mouse_pos.x, mouse_pos.y);
 	}
 
@@ -66,7 +89,7 @@ void SetupFonts(ImGuiIO& io, int fontSize) {
 
 	ImVector<ImWchar> ranges;
 	ImFontGlyphRangesBuilder builder;
-	builder.AddText(u8"â†â†’â†‘â†“");
+	builder.AddText(u8"©¨ª«");
 	builder.AddRanges(io.Fonts->GetGlyphRangesJapanese());
 	builder.BuildRanges(&ranges);
 	io.Fonts->AddFontFromMemoryCompressedTTF(noto_compressed_data, noto_compressed_size, mainFontSize, 0, ranges.Data);
@@ -86,12 +109,26 @@ void SetupFonts(ImGuiIO& io, int fontSize) {
 	io.Fonts->Build();
 }
 
+extern HRESULT __stdcall hkPresent(LPDIRECT3DSWAPCHAIN9 pSwapchain, const RECT* pSourceRect, const RECT* pDestRect, HWND hDestWindowOverride, const RGNDATA* pDirtyRegion, DWORD dwFlags);
 void InitImGui(IDirect3DDevice9* pDevice) {
 	std::cout << "[i] Direct3D device address: " << (int*)*(int*)pDevice << std::endl;
 	D3DDEVICE_CREATION_PARAMETERS CP;
 	pDevice->GetCreationParameters(&CP);
 	HWND window = CP.hFocusWindow;
+	overlay::dx9hook::hWnd = window;
 	std::cout << "[i] Window address: " << window << std::endl;
+
+	IDirect3DSwapChain9* swapchain = nullptr;
+	pDevice->GetSwapChain(0, &swapchain);
+	LPVOID present = reinterpret_cast<overlay::dx9hook::Present>((*(VOID***)swapchain)[3]);
+	MH_CreateHookEx(present, &hkPresent, &overlay::dx9hook::oPresent);
+	if (auto res = MH_EnableHook(present); res != MH_OK) {
+		std::cout << "[i] minhooy acting up..." << std::endl;
+	}
+
+	D3DCAPS9 caps{};
+	pDevice->GetDeviceCaps(&caps);
+	overlay::dx9hook::rtMax = caps.NumSimultaneousRTs;
 
 	ImGui::CreateContext();
 	ImPlot::CreateContext();
@@ -121,13 +158,17 @@ void ResetImGui(IDirect3DDevice9* pDevice)
 	D3DDEVICE_CREATION_PARAMETERS params;
 	pDevice->GetCreationParameters(&params);
 
-	ImGui_ImplWin32_Shutdown();
-	ImGui_ImplWin32_Init(params.hFocusWindow);
-
-	ImGui_ImplDX9_Shutdown();
-	ImGui_ImplDX9_Init(pDevice);
-
-	overlay::dx9hook::lastKnownDevice = pDevice;
+	if (overlay::dx9hook::hWnd != params.hFocusWindow) {
+		ImGui_ImplWin32_Shutdown();
+		ImGui_ImplWin32_Init(params.hFocusWindow);
+		overlay::dx9hook::hWnd = params.hFocusWindow;
+	}
+	
+	if (overlay::dx9hook::lastKnownDevice != pDevice) {
+		ImGui_ImplDX9_Shutdown();
+		ImGui_ImplDX9_Init(pDevice);
+		overlay::dx9hook::lastKnownDevice = pDevice;
+	}
 }
 
 void RenderNotifications() {
@@ -141,16 +182,56 @@ void RenderNotifications() {
 	ImGui::PopStyleColor(1);
 }
 
+static int sceneIdx = 0;
+HRESULT __stdcall hkPresent(LPDIRECT3DSWAPCHAIN9 pSwapchain, const RECT* pSourceRect, const RECT* pDestRect, HWND hDestWindowOverride, const RGNDATA* pDirtyRegion, DWORD dwFlags) {
+	sceneIdx = 0;
+	return overlay::dx9hook::oPresent(pSwapchain, pSourceRect, pDestRect, hDestWindowOverride, pDirtyRegion, dwFlags);
+}
+
 HRESULT __stdcall hkEndScene(IDirect3DDevice9* pDevice) {
+	int curSceneIdx = sceneIdx;
+	sceneIdx++;
+	if (curSceneIdx != 0) return overlay::dx9hook::oEndScene(pDevice);
+
 	if (!overlay::dx9hook::init) {
 		InitImGui(pDevice);
-		return overlay::dx9hook::oEndScene(pDevice);
 	}
 
-	if (overlay::dx9hook::lastKnownDevice != pDevice) ResetImGui(pDevice);
+	ResetImGui(pDevice);
+
+	auto is_minimized = [](IDirect3DDevice9* pDevice) {
+		D3DDEVICE_CREATION_PARAMETERS params{};
+		pDevice->GetCreationParameters(&params);
+		if (params.hFocusWindow == NULL) return true;
+		return IsIconic(params.hFocusWindow) == TRUE ? true : false;
+	};
+	if (is_minimized(pDevice)) return overlay::dx9hook::oEndScene(pDevice);
+
+	std::vector<IDirect3DSurface9*> rts{};
+	rts.reserve(overlay::dx9hook::rtMax);
+	for (int i = 0; i < rts.capacity(); i++) {
+		IDirect3DSurface9* rt{};
+		pDevice->GetRenderTarget(i, &rt);
+		rts.push_back(rt);
+		if (i != 0) pDevice->SetRenderTarget(i, NULL);
+	}
+	D3DSURFACE_DESC canvas{};
+	rts[0]->GetDesc(&canvas);
+
+	D3DSURFACE_DESC output{};
+	IDirect3DSurface9* backbuffer{};
+	pDevice->GetBackBuffer(0, 0, D3DBACKBUFFER_TYPE_MONO, &backbuffer);
+	backbuffer->GetDesc(&output);
+	backbuffer->Release();
+
+	overlay::dx9hook::canvas_resolution[0] = canvas.Width;
+	overlay::dx9hook::canvas_resolution[1] = canvas.Height;
+	overlay::dx9hook::output_resolution[0] = output.Width;
+	overlay::dx9hook::output_resolution[1] = output.Height;
 
 	ImGui_ImplDX9_NewFrame();
 	ImGui_ImplWin32_NewFrame();
+	ImGui::GetIO().DisplaySize = { static_cast<float>(canvas.Width), static_cast<float>(canvas.Height) };
 
 	ImGui::NewFrame();
 
@@ -167,10 +248,20 @@ HRESULT __stdcall hkEndScene(IDirect3DDevice9* pDevice) {
 	ImGui::EndFrame();
 	ImGui::Render();
 	ImGui_ImplDX9_RenderDrawData(ImGui::GetDrawData());
+
+	for (int i = 0; i < rts.size(); i++) {
+		auto& rt = rts[i];
+		pDevice->SetRenderTarget(i, rt);
+		if (rt) rt->Release();
+	}
+
 	return overlay::dx9hook::oEndScene(pDevice);
 }
 
 HRESULT __stdcall hkResetScene(IDirect3DDevice9* pDevice, D3DPRESENT_PARAMETERS* pParams) {
+	if (pDevice == NULL) {
+		return overlay::dx9hook::oResetScene(pDevice, pParams);
+	}
 	ImGui_ImplDX9_InvalidateDeviceObjects();
 	auto res = overlay::dx9hook::oResetScene(pDevice, pParams);
 	ImGui_ImplDX9_CreateDeviceObjects();
@@ -189,6 +280,11 @@ struct DxFuncs {
 	overlay::dx9hook::ResetScene resetScene = nullptr;
 };
 static std::optional<DxFuncs> GetDX9Pointers() {
+	HMODULE libD3D9;
+	std::cout << "[i] Waiting for DX9 to initialize..." << std::endl;
+	while ((libD3D9 = ::GetModuleHandle("d3d9.dll")) == NULL) {
+		std::this_thread::sleep_for(std::chrono::milliseconds(50));
+	}
 	WNDCLASSEX windowClass;
 	windowClass.cbSize = sizeof(WNDCLASSEX);
 	windowClass.style = CS_HREDRAW | CS_VREDRAW;
@@ -206,14 +302,6 @@ static std::optional<DxFuncs> GetDX9Pointers() {
 	::RegisterClassEx(&windowClass);
 
 	HWND window = ::CreateWindow(windowClass.lpszClassName, "LR2ArenaEx DirectX Window", WS_OVERLAPPEDWINDOW, 0, 0, 100, 100, NULL, NULL, windowClass.hInstance, NULL);
-
-	HMODULE libD3D9;
-	if ((libD3D9 = ::GetModuleHandle("d3d9.dll")) == NULL)
-	{
-		::DestroyWindow(window);
-		::UnregisterClass(windowClass.lpszClassName, windowClass.hInstance);
-		return std::nullopt;
-	}
 
 	void* Direct3DCreate9;
 	if ((Direct3DCreate9 = ::GetProcAddress(libD3D9, "Direct3DCreate9")) == NULL)
@@ -284,23 +372,20 @@ void overlay::dx9hook::HookDX9() {
 		std::cout << "[!] Error getting DX9 pointers" << std::endl;
 		return;
 	}
-	oEndScene = dx9Funcs->endScene;
-	oResetScene = dx9Funcs->resetScene;
 
-	if (MH_CreateHookEx((LPVOID)oEndScene, &hkEndScene, &oEndScene) != MH_OK)
+	if (MH_CreateHookEx((LPVOID)dx9Funcs->endScene, &hkEndScene, &oEndScene) != MH_OK)
 	{
 		std::cout << "[!] Error hooking EndScene" << std::endl;
 		return;
 	}
 
-	if (MH_CreateHookEx((LPVOID)oResetScene, &hkResetScene, &oResetScene) != MH_OK)
+	if (MH_CreateHookEx((LPVOID)dx9Funcs->resetScene, &hkResetScene, &oResetScene) != MH_OK)
 	{
 		std::cout << "[!] Error hooking ResetScene" << std::endl;
 		return;
 	}
 
-	oShowCursor = (ShowCursor)0x4D09E0;
-	if (MH_CreateHookEx((LPVOID)oShowCursor, &hkShowCursor, &oShowCursor) != MH_OK) // Hook hide mouse cursor
+	if (MH_CreateHookEx((LPVOID)0x4D09E0, &hkShowCursor, &oShowCursor) != MH_OK) // Hook hide mouse cursor
 	{
 		std::cout << "[!] Error hooking ShowCursor" << std::endl;
 		return;

--- a/LR2ArenaEx/src/overlay/dx9hook.cpp
+++ b/LR2ArenaEx/src/overlay/dx9hook.cpp
@@ -89,7 +89,7 @@ void SetupFonts(ImGuiIO& io, int fontSize) {
 
 	ImVector<ImWchar> ranges;
 	ImFontGlyphRangesBuilder builder;
-	builder.AddText(u8"©¨ª«");
+	builder.AddText(u8"â†â†’â†‘â†“");
 	builder.AddRanges(io.Fonts->GetGlyphRangesJapanese());
 	builder.BuildRanges(&ranges);
 	io.Fonts->AddFontFromMemoryCompressedTTF(noto_compressed_data, noto_compressed_size, mainFontSize, 0, ranges.Data);

--- a/LR2ArenaEx/src/overlay/dx9hook.h
+++ b/LR2ArenaEx/src/overlay/dx9hook.h
@@ -8,14 +8,19 @@ namespace overlay {
 	namespace dx9hook {
 		constexpr char* d3dPattern = "\x33\xC0\xC7\x06\x00\x00\x00\x00\x89\x86\x00\x00\x00\x00\x89\x86";
 		constexpr char* d3dMask = "xxxx????xx????xx?";
-		constexpr uintptr_t internal_resolution = 0x7A3B50;
+		inline int canvas_resolution[2] = { 640, 480 };
+		inline int output_resolution[2] = { 640, 480 };
 
 		typedef long(__stdcall* EndScene)(LPDIRECT3DDEVICE9);
 		inline EndScene oEndScene;
 		typedef long(__stdcall* ResetScene)(LPDIRECT3DDEVICE9, D3DPRESENT_PARAMETERS*);
 		inline ResetScene oResetScene;
+		typedef long(__stdcall* Present)(LPDIRECT3DSWAPCHAIN9, const RECT* pSourceRect, const RECT*, HWND, const RGNDATA*, DWORD);
+		inline Present oPresent;
+		inline HWND hWnd = NULL;
 		inline WNDPROC oWndProcHandler = NULL;
 		inline IDirect3DDevice9* lastKnownDevice = NULL;
+		inline int rtMax = 1;
 
 		typedef long(__cdecl* ShowCursor)(int);
 		inline ShowCursor oShowCursor;


### PR DESCRIPTION
im making a [project](https://github.com/MatVeiQaaa/UpscaLR2) which fixes fullscreen mode via updating DxLib to modified 3.24f.
Due to significant changes in render pipeline, as well as transition to dinput8, this PR is necessary. Those changes allow it work on both unmodified LR2, as well as the one with updated DxLib.